### PR TITLE
fix/kota-t/modify-the-display-order-of-images-in-top_page

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,6 +2,6 @@
 
 class TopController < ApplicationController
   def index
-    @meals = Meal.includes(dishes: { thumbnail_image_attachment: :blob }).release.limit(10).reverse
+    @meals = Meal.includes(dishes: { thumbnail_image_attachment: :blob }).release.limit(10).order(created_at: :DESC)
   end
 end


### PR DESCRIPTION
# What
- top 画面の投稿の表示順を修正（最新順で10件表示）

# Screan Shot
- before
<img width="1390" alt="スクリーンショット 2021-10-17 15 29 25" src="https://user-images.githubusercontent.com/61185362/137614773-40957ea9-d101-44d9-8d27-bf023203956f.png">

- after
<img width="1390" alt="スクリーンショット 2021-10-17 15 29 56" src="https://user-images.githubusercontent.com/61185362/137614876-683b3a19-6fd3-4419-8764-1405053638cb.png">
 