### PR TITLE
CI 結果 を slack に通知する機能を実装する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
       uses: 8398a7/action-slack@v3.8.0
       with:
         status: ${{ job.status }}
+        author_name: CI Results
+        fields: repo, message, author, action, job, took, ref, workflow
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,12 @@ jobs:
 
     - name: Run RSpec
       run: bundle exec rspec spec
+
+    - name: Notify test
+      uses: 8398a7/action-slack@v3.8.0
+      with:
+        status: ${{ job.status }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: always()

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# factory_bot 導入に伴い、動作確認の為に作成しているfactory
-# 使用する際は、factory内を修正した後、このコメントアウトを削除すること
-
 # == Schema Information
 #
 # Table name: users
@@ -22,6 +19,9 @@
 #
 #  index_users_on_uid  (uid) UNIQUE
 #
+
+# factory_bot 導入に伴い、動作確認の為に作成しているfactory
+# 使用する際は、factory内を修正した後、このコメントアウトを削除すること
 FactoryBot.define do
   factory :user do
     username { "hoge" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,26 @@
 
 # factory_bot 導入に伴い、動作確認の為に作成しているfactory
 # 使用する際は、factory内を修正した後、このコメントアウトを削除すること
+
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  description         :text(65535)
+#  display_name        :string(255)      default(""), not null
+#  email               :string(255)
+#  provider            :string(255)
+#  remember_created_at :datetime
+#  uid                 :string(255)
+#  username            :string(255)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_uid  (uid) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     username { "hoge" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                  :bigint           not null, primary key
+#  description         :text(65535)
+#  display_name        :string(255)      default(""), not null
+#  email               :string(255)
+#  provider            :string(255)
+#  remember_created_at :datetime
+#  uid                 :string(255)
+#  username            :string(255)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_uid  (uid) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
# What
- CI の結果を slack に通知する
- 通知機能は[8398a7/action-slack](https://github.com/8398a7/action-slack)を採用

# screenshot
<img width="703" alt="スクリーンショット 2021-12-15 20 14 10" src="https://user-images.githubusercontent.com/61185362/146176816-cb854303-49e7-44bf-aa07-4447d3e1ff47.png">

# やったこと
- slack app 作成（incoming webhook url の発行）
- 通知するチャンネルへ incoming webhook を追加
- github secrets へ incoming webhook url を追加
- test.yml 改修

# 参考
- https://zenn.dev/shonansurvivors/articles/fab832f7bfa8cebac24f
- https://www.yukibnb.com/entry/slack_incoming_webhook_url
- https://zenn.dev/kesin11/articles/220e68abec133b